### PR TITLE
ShowPlayers command logging on DEBUG level

### DIFF
--- a/pp_watchdog.rb
+++ b/pp_watchdog.rb
@@ -5,9 +5,9 @@ require 'csv'
 require 'fileutils'
 
 # RCON Call
-def rcon_exec(command)
+def rcon_exec(command, log_command = true)
     begin
-        $logger.info("Sending command: '#{command}'")
+        $logger.info("Sending command: '#{command}'") if log_command
         return $client.execute(command)
     rescue
         $logger.error("Failed to execute RCON Command: '#{command}'")
@@ -56,7 +56,7 @@ loop do
     end
 
     # Get player list
-    player_response = rcon_exec("ShowPlayers")
+    player_response = rcon_exec("ShowPlayers", false)
     if player_response.nil?
         $logger.warn("Skipping watchdog run due to RCON connection failure.")
         next

--- a/pp_watchdog.rb
+++ b/pp_watchdog.rb
@@ -5,9 +5,14 @@ require 'csv'
 require 'fileutils'
 
 # RCON Call
-def rcon_exec(command, log_command = true)
+def rcon_exec(command)
     begin
-        $logger.info("Sending command: '#{command}'") if log_command
+        if command == "ShowPlayers"
+            $logger.debug("Sending command: '#{command}'")
+        else
+            $logger.info("Sending command: '#{command}'")
+        end
+        
         return $client.execute(command)
     rescue
         $logger.error("Failed to execute RCON Command: '#{command}'")
@@ -56,7 +61,7 @@ loop do
     end
 
     # Get player list
-    player_response = rcon_exec("ShowPlayers", false)
+    player_response = rcon_exec("ShowPlayers")
     if player_response.nil?
         $logger.warn("Skipping watchdog run due to RCON connection failure.")
         next


### PR DESCRIPTION
Updated the `rcon_exec` method. Log messages for 'ShowPlayers' are set to DEBUG level. Other commands retain the INFO log level.

Discussion: #7 

Closes: #6 